### PR TITLE
Hover signout fix

### DIFF
--- a/svelte-todos/src/routes/+page.svelte
+++ b/svelte-todos/src/routes/+page.svelte
@@ -96,5 +96,5 @@
       Add Todo
     </button>
   </form>
-  <a href="/sign-out" class="">Sign Out</a>
+  <a href="/sign-out" class="" data-sveltekit-preload-data="off">Sign Out</a>
 </div>

--- a/svelte-todos/src/routes/me/+page.svelte
+++ b/svelte-todos/src/routes/me/+page.svelte
@@ -8,6 +8,6 @@
     <p>Here is your full payload:</p>
     <pre>{JSON.stringify(data.props, null, 2)}</pre>
     <a href="/" class="block">View Todos</a>
-    <a href="/sign-out">Log Out</a>
+    <a href="/sign-out" data-sveltekit-preload-data="off">Log Out</a>
   </main>
 {/if}


### PR DESCRIPTION
Currently if you just hover the Sign Out link without clicking it, you still get logged out. You can see this by refreshing the page

This is due to sveltekit preloading/runing load functions

I fixed this by simply using [data-sveltekit-preload-data](https://kit.svelte.dev/docs/link-options#data-sveltekit-preload-data)="off" as i wanted to keep as much as the original code